### PR TITLE
Reverse subject period validator logic

### DIFF
--- a/lib/validators/subjectPeriod.js
+++ b/lib/validators/subjectPeriod.js
@@ -23,8 +23,8 @@ function validateSubjectPeriod( firstLineText ) {
 
   const regexp = /\./;
 
-  if ( !regexp.test( lastLetter ) ) {
-    error.addError( 'subjectPeriod', 'The Subject must end with a period' );
+  if ( regexp.test( lastLetter ) ) {
+    error.addError( 'subjectPeriod', 'The Subject must not end with a period' );
   }
 }
 

--- a/lib/validators/ticketCode.js
+++ b/lib/validators/ticketCode.js
@@ -32,7 +32,7 @@ function validateticketCode( messageArray ) {
                                                   messageArray );
 
   if ( count === 0 ) {
-    error.addError( 'ticketCode', 'You did not used a ticked code in your commit message' );
+    error.addError( 'ticketCode', 'You did not used a ticket code in your commit message' );
   }
 
   if ( isOnlyOneAllowed() && count > 1 ) {

--- a/test/lib/validators/subjectPeriod.test.js
+++ b/test/lib/validators/subjectPeriod.test.js
@@ -21,17 +21,17 @@ suite( 'Validators.subjectPeriod | ', () => {
     done();
   } );
 
-  test( 'Does not throw error if the subject ends with period', () => {
+  test( 'Throws an error if the subject ends with a period', () => {
     const commitLines = [ 'Allow to do a nice validation.', '', 'Create a map commit.', '' ];
     const hasErrors = subjectPeriod.validate( commitLines );
-    assert.equal( hasErrors, false );
+    assert.equal( hasErrors, true );
   } );
 
-  test( 'Throws an error if subject does not end with period', () => {
+  test( 'Throws an error if subject does not end with a period', () => {
     const validLines = [ 'handles something', 'asdas', 'Create at.', 'foo' ];
     const hasErrors = subjectPeriod.validate( validLines );
 
-    assert.equal( hasErrors, true, 'The first word is not capitalized' );
+    assert.equal( hasErrors, false, 'The first word is not capitalized' );
   } );
 
   test( 'Should not be errors if the validator is not enabled or not config object', () => {


### PR DESCRIPTION
The subject period rule is the opposite from most prior art. The validator should ensure that there is not a period at the end of the subject.

https://github.com/m1foley/fit-commit#validations

http://chris.beams.io/posts/git-commit/#end

http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html