### PR TITLE
Remove flag from shebang

### DIFF
--- a/lib/hook.js
+++ b/lib/hook.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --use-strict
+#!/usr/bin/env node
 
 'use strict';
 


### PR DESCRIPTION
On linux it seems that you can't use multiple arguments in a shebang.
At least on my system I can't!

This means that on my system I get the following:

/usr/bin/env: ‘node --use-strict’: No such file or directory

Dropping the '--use-strict' works as expected.