### PR TITLE
Ignore lines after verbose commit marker

### DIFF
--- a/lib/message/parser.js
+++ b/lib/message/parser.js
@@ -27,11 +27,20 @@ function getLinesArray( message ) {
  * @private
  */
 function isLineRelevant( line ) {
-  const GIT_VERBOSE_MARKER = '# ------------------------ >8 ------------------------';
   const COMMENT_REGEX = /(#)/;
   const isComment = ( R.match( COMMENT_REGEX, line ).length > 0 );
-  return ( line !== GIT_VERBOSE_MARKER && !isComment );
+  return !isComment;
 }
+
+const GIT_VERBOSE_MARKER = '# ------------------------ >8 ------------------------';
+
+const notVerboseMarker = ( _, line ) => line !== GIT_VERBOSE_MARKER;
+
+const appendRelevant = ( acc, line ) => (
+  isLineRelevant( line )
+    ? R.append( line, acc )
+    : acc
+);
 
 /*
    Public
@@ -47,7 +56,7 @@ function getRelevantLines( message ) {
   let relevantLines = [];
   if ( message ) {
     const lines = getLinesArray( message );
-    relevantLines = R.values( R.pickBy( isLineRelevant, lines ) );
+    relevantLines = R.reduceWhile( notVerboseMarker, appendRelevant, [], lines );
   } else {
     log.error( 'message/parser', 'Tried to parse the commit message but none found' );
   }

--- a/test/lib/message/parser.test.js
+++ b/test/lib/message/parser.test.js
@@ -2,18 +2,34 @@ const assert = require( 'chai' ).assert;
 const parser = require( '../../../lib/message/parser' );
 
 suite( 'Message.Parser | ', () => {
-  const message = `This is a relevant line
-
-  # Please enter the commit message for your changes. Lines starting
-  # with '#' will be ignored, and an empty message aborts the commit.
-  # On branch feature/create-executable-git-hook`;
-
   suiteTeardown( ( done ) => {
     done();
   } );
 
   test( 'Should get the relevant lines out of the message', () => {
+    const message = `This is a relevant line
+
+  # Please enter the commit message for your changes. Lines starting
+  # with '#' will be ignored, and an empty message aborts the commit.
+  # On branch feature/create-executable-git-hook`;
+
     const parsedMessage = parser.getRelevantLines( message );
     assert.equal( parsedMessage[ 0 ], 'This is a relevant line' );
+  } );
+
+  test( 'Should ignore everything below the verbose commit line', () => {
+    const message =
+`Some commit message
+# Blah
+# ------------------------ >8 ------------------------
+# Something
+All
+the
+sometimes extra-long lines of diff stuff that get picked up even though they're below the verbose line`;
+
+    const lines = parser.getRelevantLines( message );
+    assert.deepEqual( lines, [
+      'Some commit message',
+    ] );
   } );
 } );


### PR DESCRIPTION
All lines after the marker should be ignored but it was actually picking
up the diff lines some of which hit the line-length constraint.